### PR TITLE
release: pckg-c v1.0.1

### DIFF
--- a/packages/pckg-c/CHANGELOG.md
+++ b/packages/pckg-c/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 1.0.1 (2025-07-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-b bumped from ^1.0.0 to ^1.0.1

--- a/packages/pckg-c/package.json
+++ b/packages/pckg-c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-c",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-c\""
   },
   "dependencies": {
-    "pckg-b": "^1.0.0"
+    "pckg-b": "^1.0.1"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## 1.0.1 (2025-07-04)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-b bumped from ^1.0.0 to ^1.0.1

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).