### PR TITLE
release: pckg-d v1.0.2

### DIFF
--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.1...pckg-d-v1.0.2) (2025-07-04)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-c bumped from ^1.0.1 to ^1.0.2
+
 ## 1.0.1 (2025-07-04)
 
 

--- a/packages/pckg-d/package.json
+++ b/packages/pckg-d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-d",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-d\""
   },
   "dependencies": {
-    "pckg-c": "^1.0.1"
+    "pckg-c": "^1.0.2"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.1...pckg-d-v1.0.2) (2025-07-04)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-c bumped from ^1.0.1 to ^1.0.2

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).