### PR TITLE
release: pckg-d v1.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.1","packages/pckg-c":"1.0.3","packages/pckg-d":"1.0.3"}
+{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.1","packages/pckg-c":"1.0.3","packages/pckg-d":"1.1.0"}

--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.3...pckg-d-v1.1.0) (2025-07-04)
+
+
+### Features
+
+* What a feature! ([c9bb8c6](https://github.com/d3xter666/release-please-monorepo-poc/commit/c9bb8c6fb4adaef85d52d91868daebf609ff282e))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-c bumped from ^1.0.2 to ^1.0.3
+
 ## [1.0.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.1...pckg-d-v1.0.2) (2025-07-04)
 
 

--- a/packages/pckg-d/package.json
+++ b/packages/pckg-d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-d",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-d\""
   },
   "dependencies": {
-    "pckg-c": "^1.0.2"
+    "pckg-c": "^1.0.3"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.3...pckg-d-v1.1.0) (2025-07-04)


### Features

* What a feature! ([c9bb8c6](https://github.com/d3xter666/release-please-monorepo-poc/commit/c9bb8c6fb4adaef85d52d91868daebf609ff282e))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-c bumped from ^1.0.2 to ^1.0.3

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).