### PR TITLE
release: pckg-b v1.0.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.0"}
+{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.0","packages/pckg-c":"1.0.3","packages/pckg-d":"1.0.3"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,7 +1968,7 @@
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.0.3",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "pckg-a": "^1.3.1"
@@ -1978,7 +1978,7 @@
       "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.0.3"
+        "pckg-b": "^1.0.1"
       }
     },
     "packages/pckg-d": {

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.0.0...pckg-b-v1.0.1) (2025-07-04)
+
+
+### Bug Fixes
+
+* Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))
+
 ## 1.0.0 (2025-07-04)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.0.0...pckg-b-v1.0.1) (2025-07-04)


### Bug Fixes

* Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).