### PR TITLE
release: pckg-b v1.0.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.0","packages/pckg-c":"1.0.3","packages/pckg-d":"1.0.3"}
+{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.1","packages/pckg-c":"1.0.3","packages/pckg-d":"1.0.3"}

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -7,6 +7,20 @@
 
 * Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))
 
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-a bumped from ^1.0.0 to ^1.1.2
+
+## [1.0.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.0.0...pckg-b-v1.0.1) (2025-07-04)
+
+
+### Bug Fixes
+
+* Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))
+
 ## 1.0.0 (2025-07-04)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-b\""
   },
   "dependencies": {
-    "pckg-a": "^1.0.0"
+    "pckg-a": "^1.1.2"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.0.0...pckg-b-v1.0.1) (2025-07-04)


### Bug Fixes

* Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-a bumped from ^1.0.0 to ^1.1.2

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).