### PR TITLE
release: pckg-a v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1964,14 +1964,14 @@
       }
     },
     "packages/pckg-a": {
-      "version": "1.3.1",
+      "version": "1.1.2",
       "license": "ISC"
     },
     "packages/pckg-b": {
       "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
-        "pckg-a": "^1.3.1"
+        "pckg-a": "^1.1.2"
       }
     },
     "packages/pckg-c": {

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-04)
+
+
+### Bug Fixes
+
+* Little fix in A ([e45b5c0](https://github.com/d3xter666/release-please-monorepo-poc/commit/e45b5c0b39d1595980e0fb672de1f0d7aef3f223))
+
 ## [1.1.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.0...pckg-a-v1.1.1) (2025-07-04)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-04)


### Bug Fixes

* Little fix in A ([e45b5c0](https://github.com/d3xter666/release-please-monorepo-poc/commit/e45b5c0b39d1595980e0fb672de1f0d7aef3f223))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).