### PR TITLE
release: pckg-d v1.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.2","packages/pckg-c":"1.0.3","packages/pckg-d":"1.1.0"}
+{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.0.2","packages/pckg-c":"1.0.3","packages/pckg-d":"1.1.1"}

--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.1.0...pckg-d-v1.1.1) (2025-07-04)
+
+
+### Bug Fixes
+
+* A little fix ([2537e66](https://github.com/d3xter666/release-please-monorepo-poc/commit/2537e66bb8577eea8928a7109666c68b8f0b437d))
+
 ## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.3...pckg-d-v1.1.0) (2025-07-04)
 
 

--- a/packages/pckg-d/package.json
+++ b/packages/pckg-d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-d",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.1.0...pckg-d-v1.1.1) (2025-07-04)


### Bug Fixes

* A little fix ([2537e66](https://github.com/d3xter666/release-please-monorepo-poc/commit/2537e66bb8577eea8928a7109666c68b8f0b437d))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).