### PR TITLE
release: pckg-d v1.3.1

### DIFF
--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.3.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.3.0...pckg-d-v1.3.1) (2025-07-09)
+
 ## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.2.1...pckg-d-v1.3.0) (2025-07-09)
 
 

--- a/packages/pckg-d/package.json
+++ b/packages/pckg-d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-d",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.3.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.3.0...pckg-d-v1.3.1) (2025-07-09)

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).