### PR TITLE
release: pckg-a v1.1.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.2.0","packages/pckg-c":"1.0.4","packages/pckg-d":"1.3.0"}
+{"packages/pckg-a":"1.1.1","packages/pckg-b":"1.2.1","packages/pckg-c":"1.0.4","packages/pckg-d":"1.3.1"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,7 +1968,7 @@
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "pckg-a": "^1.1.2"
@@ -1978,11 +1978,11 @@
       "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.2.0"
+        "pckg-b": "^1.2.1"
       }
     },
     "packages/pckg-d": {
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "pckg-c": "^1.0.4"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -28,6 +28,13 @@
 
 * Little fix in A ([e45b5c0](https://github.com/d3xter666/release-please-monorepo-poc/commit/e45b5c0b39d1595980e0fb672de1f0d7aef3f223))
 
+## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-09)
+
+
+### Bug Fixes
+
+* Little fix in A ([e45b5c0](https://github.com/d3xter666/release-please-monorepo-poc/commit/e45b5c0b39d1595980e0fb672de1f0d7aef3f223))
+
 ## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-04)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-09)


### Bug Fixes

* Little fix in A ([e45b5c0](https://github.com/d3xter666/release-please-monorepo-poc/commit/e45b5c0b39d1595980e0fb672de1f0d7aef3f223))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).