### PR TITLE
release: pckg-a v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1964,25 +1964,25 @@
       }
     },
     "packages/pckg-a": {
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
-        "pckg-a": "^1.1.2"
+        "pckg-a": "^1.2.0"
       }
     },
     "packages/pckg-c": {
       "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.2.1"
+        "pckg-b": "^1.3.0"
       }
     },
     "packages/pckg-d": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "pckg-c": "^1.0.4"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-09)
+
+
+### Features
+
+* Feature for pckg-A ([b45a942](https://github.com/d3xter666/release-please-monorepo-poc/commit/b45a9422f19e6efbeacd32a71a48e78b1826d006))
+
 ## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-09)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-09)


### Features

* Feature for pckg-A ([b45a942](https://github.com/d3xter666/release-please-monorepo-poc/commit/b45a9422f19e6efbeacd32a71a48e78b1826d006))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).