### PR TITLE
release: pckg-a v1.2.0

### DIFF
--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 * Feature for pckg-A ([b45a942](https://github.com/d3xter666/release-please-monorepo-poc/commit/b45a9422f19e6efbeacd32a71a48e78b1826d006))
 
+## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-09)
+
+
+### Features
+
+* Feature for pckg-A ([b45a942](https://github.com/d3xter666/release-please-monorepo-poc/commit/b45a9422f19e6efbeacd32a71a48e78b1826d006))
+
 ## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-09)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-09)


### Features

* Feature for pckg-A ([b45a942](https://github.com/d3xter666/release-please-monorepo-poc/commit/b45a9422f19e6efbeacd32a71a48e78b1826d006))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).