### PR TITLE
release: pckg-d v1.4.1

### DIFF
--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 * Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))
 
+## [1.4.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.4.0...pckg-d-v1.4.1) (2025-07-09)
+
+
+### Bug Fixes
+
+* Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))
+
 ## [1.4.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.3.1...pckg-d-v1.4.0) (2025-07-09)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.4.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.4.0...pckg-d-v1.4.1) (2025-07-09)


### Bug Fixes

* Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).