### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.2.0",
-  "packages/pckg-b": "1.3.0",
-  "packages/pckg-c": "1.0.4",
-  "packages/pckg-d": "1.4.0"
+  "packages/pckg-b": "1.4.0",
+  "packages/pckg-c": "1.0.5",
+  "packages/pckg-d": "1.5.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,24 +1968,24 @@
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "pckg-a": "^1.2.0"
       }
     },
     "packages/pckg-c": {
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.3.0"
+        "pckg-b": "^1.4.0"
       }
     },
     "packages/pckg-d": {
       "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
-        "pckg-c": "^1.0.4"
+        "pckg-c": "^1.0.5"
       }
     }
   }

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.4.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.3.0...pckg-b-v1.4.0) (2025-07-09)
+
+
+### Features
+
+* It's a feature ([19dbefb](https://github.com/d3xter666/release-please-monorepo-poc/commit/19dbefb743b974766d666b519e19fcb93a5cf3bc))
+
 ## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.1...pckg-b-v1.3.0) (2025-07-09)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "license": "ISC",
   "author": "",

--- a/packages/pckg-c/CHANGELOG.md
+++ b/packages/pckg-c/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.5](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.4...pckg-c-v1.0.5) (2025-07-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-b bumped from ^1.3.1 to ^1.4.0
+
 ## [1.0.4](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.4...pckg-c-v1.0.4) (2025-07-09)
 
 

--- a/packages/pckg-c/package.json
+++ b/packages/pckg-c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-c",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-c\""
   },
   "dependencies": {
-    "pckg-b": "^1.3.1"
+    "pckg-b": "^1.4.0"
   }
 }

--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -11,6 +11,27 @@
 
 ### Bug Fixes
 
+* It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))
+* Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-c bumped from ^1.0.4 to ^1.0.5
+
+## [1.5.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.4.0...pckg-d-v1.5.0) (2025-07-09)
+
+
+### Features
+
+* A new feature for D ([0373080](https://github.com/d3xter666/release-please-monorepo-poc/commit/03730802680af9e18a8ba497e34250a2c50dba26))
+* Another feature ([6918b1c](https://github.com/d3xter666/release-please-monorepo-poc/commit/6918b1c1aba0d834f5bedd3b587c2d9cf75375a2))
+
+
+### Bug Fixes
+
 * Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))
 
 ## [1.5.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.4.0...pckg-d-v1.5.0) (2025-07-09)

--- a/packages/pckg-d/package.json
+++ b/packages/pckg-d/package.json
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-d\""
   },
   "dependencies": {
-    "pckg-c": "^1.0.4"
+    "pckg-c": "^1.0.5"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


<details><summary>pckg-b: 1.4.0</summary>

## [1.4.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.3.0...pckg-b-v1.4.0) (2025-07-09)


### Features

* It's a feature ([19dbefb](https://github.com/d3xter666/release-please-monorepo-poc/commit/19dbefb743b974766d666b519e19fcb93a5cf3bc))
</details>

<details><summary>pckg-c: 1.0.5</summary>

## [1.0.5](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.4...pckg-c-v1.0.5) (2025-07-09)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-b bumped from ^1.3.1 to ^1.4.0
</details>

<details><summary>pckg-d: 1.5.0</summary>

## [1.5.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.4.0...pckg-d-v1.5.0) (2025-07-09)


### Features

* A new feature for D ([0373080](https://github.com/d3xter666/release-please-monorepo-poc/commit/03730802680af9e18a8ba497e34250a2c50dba26))
* Another feature ([6918b1c](https://github.com/d3xter666/release-please-monorepo-poc/commit/6918b1c1aba0d834f5bedd3b587c2d9cf75375a2))


### Bug Fixes

* It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))
* Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-c bumped from ^1.0.4 to ^1.0.5
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).