### PR TITLE
release: pckg-c v1.0.6

### DIFF
--- a/packages/pckg-c/CHANGELOG.md
+++ b/packages/pckg-c/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.6](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.6...pckg-c-v1.0.6) (2025-07-09)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-b bumped from ^1.4.0 to ^1.5.0
+
 ## [1.0.5](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.4...pckg-c-v1.0.5) (2025-07-09)
 
 

--- a/packages/pckg-c/package.json
+++ b/packages/pckg-c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-c",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-c\""
   },
   "dependencies": {
-    "pckg-b": "^1.4.0"
+    "pckg-b": "^1.5.0"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.6](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.5...pckg-c-v1.0.6) (2025-07-09)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-b bumped from ^1.4.0 to ^1.5.0

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).