### PR TITLE
release: pckg-b v1.5.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.2.0",
   "packages/pckg-b": "1.4.0",
-  "packages/pckg-c": "1.0.5",
+  "packages/pckg-c": "1.0.6",
   "packages/pckg-d": "1.5.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,24 +1968,24 @@
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "pckg-a": "^1.2.0"
       }
     },
     "packages/pckg-c": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.4.0"
+        "pckg-b": "^1.5.0"
       }
     },
     "packages/pckg-d": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
-        "pckg-c": "^1.0.5"
+        "pckg-c": "^1.0.6"
       }
     }
   }

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.4.0...pckg-b-v1.5.0) (2025-07-09)
+
+
+### Features
+
+* Another feature for B ([dede3ae](https://github.com/d3xter666/release-please-monorepo-poc/commit/dede3ae8c5212fb40e6b156eb38f1600c69a5a6c))
+
 ## [1.4.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.3.0...pckg-b-v1.4.0) (2025-07-09)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.5.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.4.0...pckg-b-v1.5.0) (2025-07-09)


### Features

* Another feature for B ([dede3ae](https://github.com/d3xter666/release-please-monorepo-poc/commit/dede3ae8c5212fb40e6b156eb38f1600c69a5a6c))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).