### PR TITLE
release: pckg-c v1.0.7

### DIFF
--- a/packages/pckg-c/CHANGELOG.md
+++ b/packages/pckg-c/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.0.7](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.6...pckg-c-v1.0.7) (2025-07-09)
+
 ## [1.0.6](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.6...pckg-c-v1.0.6) (2025-07-09)
 
 

--- a/packages/pckg-c/package.json
+++ b/packages/pckg-c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-c",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.7](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.6...pckg-c-v1.0.7) (2025-07-09)

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).