### PR TITLE
release: pckg-d v1.6.0

### DIFF
--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -13,6 +13,19 @@
 * Another fix for D ([5e3d644](https://github.com/d3xter666/release-please-monorepo-poc/commit/5e3d644d65530dd70b1b18dbe23fae78f2ecdf93))
 * It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))
 
+## [1.6.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.5.0...pckg-d-v1.6.0) (2025-07-10)
+
+
+### Features
+
+* Another feature ([6918b1c](https://github.com/d3xter666/release-please-monorepo-poc/commit/6918b1c1aba0d834f5bedd3b587c2d9cf75375a2))
+
+
+### Bug Fixes
+
+* Another fix for D ([5e3d644](https://github.com/d3xter666/release-please-monorepo-poc/commit/5e3d644d65530dd70b1b18dbe23fae78f2ecdf93))
+* It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))
+
 ## [1.6.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.5.0...pckg-d-v1.6.0) (2025-07-09)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.6.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.5.0...pckg-d-v1.6.0) (2025-07-10)


### Features

* Another feature ([6918b1c](https://github.com/d3xter666/release-please-monorepo-poc/commit/6918b1c1aba0d834f5bedd3b587c2d9cf75375a2))


### Bug Fixes

* Another fix for D ([5e3d644](https://github.com/d3xter666/release-please-monorepo-poc/commit/5e3d644d65530dd70b1b18dbe23fae78f2ecdf93))
* It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).