### PR TITLE
release: pckg-b v1.5.1

### DIFF
--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.5.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.5.0...pckg-b-v1.5.1) (2025-07-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-a bumped from ^1.2.0 to ^1.3.0
+
 ## [1.5.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.4.0...pckg-b-v1.5.0) (2025-07-09)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-b\""
   },
   "dependencies": {
-    "pckg-a": "^1.2.0"
+    "pckg-a": "^1.3.0"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.5.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.5.0...pckg-b-v1.5.1) (2025-07-10)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-a bumped from ^1.2.0 to ^1.3.0

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).