### PR TITLE
release: pckg-c v1.0.7

### DIFF
--- a/packages/pckg-c/CHANGELOG.md
+++ b/packages/pckg-c/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.8](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.7...pckg-c-v1.0.8) (2025-07-10)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-b bumped from ^1.5.1 to ^1.6.2
+
 ## [1.0.7](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.6...pckg-c-v1.0.7) (2025-07-10)
 
 

--- a/packages/pckg-c/package.json
+++ b/packages/pckg-c/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-c",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-c\""
   },
   "dependencies": {
-    "pckg-b": "^1.5.1"
+    "pckg-b": "^1.6.2"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.7](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.7...pckg-c-v1.0.7) (2025-07-10)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-b bumped from ^1.5.0 to ^1.6.0

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).