### PR TITLE
release: pckg-a v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,7 +1968,7 @@
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "pckg-a": "^1.3.0"
@@ -1978,11 +1978,11 @@
       "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.5.1"
+        "pckg-b": "^1.6.0"
       }
     },
     "packages/pckg-d": {
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "ISC",
       "dependencies": {
         "pckg-c": "^1.0.7"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 * Package A ([e773e45](https://github.com/d3xter666/release-please-monorepo-poc/commit/e773e452defd86b39cef8f11b15f851f368f5d81))
 
+## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.0...pckg-a-v1.3.0) (2025-07-10)
+
+
+### Features
+
+* Package A ([e773e45](https://github.com/d3xter666/release-please-monorepo-poc/commit/e773e452defd86b39cef8f11b15f851f368f5d81))
+
 ## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-09)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.0...pckg-a-v1.3.0) (2025-07-10)


### Features

* Package A ([e773e45](https://github.com/d3xter666/release-please-monorepo-poc/commit/e773e452defd86b39cef8f11b15f851f368f5d81))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).