### PR TITLE
release: pckg-b v1.6.1

### DIFF
--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [1.6.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.6.0...pckg-b-v1.6.1) (2025-07-10)
+
 ## [1.6.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.5.1...pckg-b-v1.6.0) (2025-07-10)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.6.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.6.0...pckg-b-v1.6.1) (2025-07-10)

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).