### PR TITLE
release: pckg-a v1.3.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.2.0",
-  "packages/pckg-b": "1.6.0",
-  "packages/pckg-c": "1.0.7",
-  "packages/pckg-d": "1.6.1"
+  "packages/pckg-b": "1.6.2",
+  "packages/pckg-c": "1.0.8",
+  "packages/pckg-d": "1.6.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1968,24 +1968,24 @@
       "license": "ISC"
     },
     "packages/pckg-b": {
-      "version": "1.6.0",
+      "version": "1.6.2",
       "license": "ISC",
       "dependencies": {
         "pckg-a": "^1.3.0"
       }
     },
     "packages/pckg-c": {
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
-        "pckg-b": "^1.6.0"
+        "pckg-b": "^1.6.2"
       }
     },
     "packages/pckg-d": {
-      "version": "1.7.0",
+      "version": "1.6.2",
       "license": "ISC",
       "dependencies": {
-        "pckg-c": "^1.0.7"
+        "pckg-c": "^1.0.8"
       }
     }
   }

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -14,6 +14,13 @@
 
 * Package A ([e773e45](https://github.com/d3xter666/release-please-monorepo-poc/commit/e773e452defd86b39cef8f11b15f851f368f5d81))
 
+## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.0...pckg-a-v1.3.0) (2025-07-10)
+
+
+### Features
+
+* Package A ([e773e45](https://github.com/d3xter666/release-please-monorepo-poc/commit/e773e452defd86b39cef8f11b15f851f368f5d81))
+
 ## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-09)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.0...pckg-a-v1.3.0) (2025-07-10)


### Features

* Package A ([e773e45](https://github.com/d3xter666/release-please-monorepo-poc/commit/e773e452defd86b39cef8f11b15f851f368f5d81))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).