### PR TITLE
release: pckg-b v1.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.0.0",
-  "packages/pckg-b": "1.0.0",
+  "packages/pckg-b": "1.1.0",
   "packages/pckg-c": "1.0.0",
   "packages/pckg-d": "1.0.0"
 }

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.0.0...pckg-b-v1.1.0) (2025-07-10)
+
+
+### Features
+
+* Another feature for B ([dede3ae](https://github.com/d3xter666/release-please-monorepo-poc/commit/dede3ae8c5212fb40e6b156eb38f1600c69a5a6c))
+* Feat in B ([8c5286a](https://github.com/d3xter666/release-please-monorepo-poc/commit/8c5286a3b20f434031c401bc3048cd87fd538186))
+* It's a feature ([19dbefb](https://github.com/d3xter666/release-please-monorepo-poc/commit/19dbefb743b974766d666b519e19fcb93a5cf3bc))
+
+
+### Bug Fixes
+
+* Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-a bumped from ^1.0.0 to ^1.1.0

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-b\""
   },
   "dependencies": {
-    "pckg-a": "^1.0.0"
+    "pckg-a": "^1.1.0"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.0.0...pckg-b-v1.1.0) (2025-07-10)


### Features

* Another feature for B ([dede3ae](https://github.com/d3xter666/release-please-monorepo-poc/commit/dede3ae8c5212fb40e6b156eb38f1600c69a5a6c))
* Feat in B ([8c5286a](https://github.com/d3xter666/release-please-monorepo-poc/commit/8c5286a3b20f434031c401bc3048cd87fd538186))
* It's a feature ([19dbefb](https://github.com/d3xter666/release-please-monorepo-poc/commit/19dbefb743b974766d666b519e19fcb93a5cf3bc))


### Bug Fixes

* Little fix ([c93f2da](https://github.com/d3xter666/release-please-monorepo-poc/commit/c93f2da7ca4f8311ef99217b97cd6039ce3ace9a))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-a bumped from ^1.0.0 to ^1.1.0

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).