### PR TITLE
release: pckg-d v1.1.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,5 @@
   "packages/pckg-a": "1.0.0",
   "packages/pckg-b": "1.0.0",
   "packages/pckg-c": "1.0.0",
-  "packages/pckg-d": "1.0.0"
+  "packages/pckg-d": "1.1.0"
 }

--- a/packages/pckg-d/CHANGELOG.md
+++ b/packages/pckg-d/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.0...pckg-d-v1.1.0) (2025-07-10)
+
+
+### Features
+
+* A new feature for D ([0373080](https://github.com/d3xter666/release-please-monorepo-poc/commit/03730802680af9e18a8ba497e34250a2c50dba26))
+* Another feature ([6918b1c](https://github.com/d3xter666/release-please-monorepo-poc/commit/6918b1c1aba0d834f5bedd3b587c2d9cf75375a2))
+* What a feature! ([c9bb8c6](https://github.com/d3xter666/release-please-monorepo-poc/commit/c9bb8c6fb4adaef85d52d91868daebf609ff282e))
+
+
+### Bug Fixes
+
+* A little fix ([2537e66](https://github.com/d3xter666/release-please-monorepo-poc/commit/2537e66bb8577eea8928a7109666c68b8f0b437d))
+* Another fix for D ([5e3d644](https://github.com/d3xter666/release-please-monorepo-poc/commit/5e3d644d65530dd70b1b18dbe23fae78f2ecdf93))
+* It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))
+* Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))
+* Pckg-d ([132d5cf](https://github.com/d3xter666/release-please-monorepo-poc/commit/132d5cfdc446a5a72a5594d4f7a06b2aee96b742))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * pckg-c bumped from ^1.0.0 to ^1.0.1

--- a/packages/pckg-d/package.json
+++ b/packages/pckg-d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-d",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "license": "ISC",
   "author": "",
@@ -10,6 +10,6 @@
     "test": "echo \"Run tests for pckg-d\""
   },
   "dependencies": {
-    "pckg-c": "^1.0.0"
+    "pckg-c": "^1.0.1"
   }
 }


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-d-v1.0.0...pckg-d-v1.1.0) (2025-07-10)


### Features

* A new feature for D ([0373080](https://github.com/d3xter666/release-please-monorepo-poc/commit/03730802680af9e18a8ba497e34250a2c50dba26))
* Another feature ([6918b1c](https://github.com/d3xter666/release-please-monorepo-poc/commit/6918b1c1aba0d834f5bedd3b587c2d9cf75375a2))
* What a feature! ([c9bb8c6](https://github.com/d3xter666/release-please-monorepo-poc/commit/c9bb8c6fb4adaef85d52d91868daebf609ff282e))


### Bug Fixes

* A little fix ([2537e66](https://github.com/d3xter666/release-please-monorepo-poc/commit/2537e66bb8577eea8928a7109666c68b8f0b437d))
* Another fix for D ([5e3d644](https://github.com/d3xter666/release-please-monorepo-poc/commit/5e3d644d65530dd70b1b18dbe23fae78f2ecdf93))
* It's a fix ([b1c78a7](https://github.com/d3xter666/release-please-monorepo-poc/commit/b1c78a73dbaef8a1118567ebfc95c59b0feaf4e9))
* Little fix. Nothing more expected ([364349d](https://github.com/d3xter666/release-please-monorepo-poc/commit/364349d3eb6239b1ae416c80a8ef22eecd5c3668))
* Pckg-d ([132d5cf](https://github.com/d3xter666/release-please-monorepo-poc/commit/132d5cfdc446a5a72a5594d4f7a06b2aee96b742))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * pckg-c bumped from ^1.0.0 to ^1.0.1

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).