### PR TITLE
release: pckg-a v1.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/pckg-a": "1.1.0",
+  "packages/pckg-a": "1.1.1",
   "packages/pckg-b": "1.2.0",
   "packages/pckg-c": "1.0.1",
   "packages/pckg-d": "1.1.0"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.0...pckg-a-v1.1.1) (2025-07-10)
+
+
+### Bug Fixes
+
+* Try to fix only pckg-a and bump versions of the other components ([2870c2d](https://github.com/d3xter666/release-please-monorepo-poc/commit/2870c2dc946df84994e55ef01c316aa86f1648d5))
+
 ## [1.1.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.0.0...pckg-a-v1.1.0) (2025-07-10)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.0...pckg-a-v1.1.1) (2025-07-10)


### Bug Fixes

* Try to fix only pckg-a and bump versions of the other components ([2870c2d](https://github.com/d3xter666/release-please-monorepo-poc/commit/2870c2dc946df84994e55ef01c316aa86f1648d5))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).