### PR TITLE
release: pckg-c v1.0.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.1.1",
   "packages/pckg-b": "1.2.0",
-  "packages/pckg-c": "1.0.1",
+  "packages/pckg-c": "1.0.2",
   "packages/pckg-d": "1.1.0"
 }

--- a/packages/pckg-c/CHANGELOG.md
+++ b/packages/pckg-c/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [1.0.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.1...pckg-c-v1.0.2) (2025-07-10)
+
+
+### Dependencies
+
+* **pckg-c:** Bump version due to pckg-b update ([6d3299d](https://github.com/d3xter666/release-please-monorepo-poc/commit/6d3299da8c116cb30bec491e3ed06ce1563a3421))
+* **pckg-c:** Bump version due to pckg-b update ([4a21804](https://github.com/d3xter666/release-please-monorepo-poc/commit/4a218043ea6fdc83936c026658977200d63c1cc9))


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.0.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-c-v1.0.1...pckg-c-v1.0.2) (2025-07-10)


### Dependencies

* **pckg-c:** Bump version due to pckg-b update ([6d3299d](https://github.com/d3xter666/release-please-monorepo-poc/commit/6d3299da8c116cb30bec491e3ed06ce1563a3421))
* **pckg-c:** Bump version due to pckg-b update ([4a21804](https://github.com/d3xter666/release-please-monorepo-poc/commit/4a218043ea6fdc83936c026658977200d63c1cc9))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).