### PR TITLE
release: pckg-b v1.2.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.1.1",
-  "packages/pckg-b": "1.2.0",
+  "packages/pckg-b": "1.2.1",
   "packages/pckg-c": "1.0.1",
   "packages/pckg-d": "1.1.0"
 }

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.2.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.0...pckg-b-v1.2.1) (2025-07-10)
+
+
+### Dependencies
+
+* **pckg-b:** Bump version due to pckg-a update ([1ec132b](https://github.com/d3xter666/release-please-monorepo-poc/commit/1ec132bf57abb73476b20ab76226823ffe6f723d))
+* **pckg-b:** Bump version due to pckg-a update ([729d7a6](https://github.com/d3xter666/release-please-monorepo-poc/commit/729d7a63b184ac3a785c99ce17cf37722eeecc6c))
+* **pckg-b:** Bump version due to pckg-a update ([1a38c79](https://github.com/d3xter666/release-please-monorepo-poc/commit/1a38c7986cf1b99ff620dbd2642724c0cedd8ead))
+
 ## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.1.0...pckg-b-v1.2.0) (2025-07-10)
 
 

--- a/packages/pckg-b/package.json
+++ b/packages/pckg-b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-b",
-  "version": "1.2.3",
+  "version": "1.2.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.0...pckg-b-v1.2.1) (2025-07-10)


### Dependencies

* **pckg-b:** Bump version due to pckg-a update ([1ec132b](https://github.com/d3xter666/release-please-monorepo-poc/commit/1ec132bf57abb73476b20ab76226823ffe6f723d))
* **pckg-b:** Bump version due to pckg-a update ([729d7a6](https://github.com/d3xter666/release-please-monorepo-poc/commit/729d7a63b184ac3a785c99ce17cf37722eeecc6c))
* **pckg-b:** Bump version due to pckg-a update ([1a38c79](https://github.com/d3xter666/release-please-monorepo-poc/commit/1a38c7986cf1b99ff620dbd2642724c0cedd8ead))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).