### PR TITLE
release: pckg-b v1.2.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.1.1",
-  "packages/pckg-b": "1.2.1",
+  "packages/pckg-b": "1.2.2",
   "packages/pckg-c": "1.0.2",
   "packages/pckg-d": "1.1.0"
 }

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.1...pckg-b-v1.2.2) (2025-07-11)
+
+
+### Dependencies
+
+* **pckg-b:** Bump version due to pckg-a update ([5946af3](https://github.com/d3xter666/release-please-monorepo-poc/commit/5946af387b7921fdf299114ee7678521dba1a838))
+
 ## [1.2.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.0...pckg-b-v1.2.1) (2025-07-10)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.1...pckg-b-v1.2.2) (2025-07-11)


### Dependencies

* **pckg-b:** Bump version due to pckg-a update ([5946af3](https://github.com/d3xter666/release-please-monorepo-poc/commit/5946af387b7921fdf299114ee7678521dba1a838))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).