### PR TITLE
release: pckg-a v1.1.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/pckg-a": "1.1.1",
+  "packages/pckg-a": "1.1.2",
   "packages/pckg-b": "1.2.2",
   "packages/pckg-c": "1.1.1",
   "packages/pckg-d": "1.1.0"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-11)
+
+
+### Bug Fixes
+
+* Fix in A ([18982e5](https://github.com/d3xter666/release-please-monorepo-poc/commit/18982e5eefaaa2e8341c2a2030087939e6de3b27))
+
 ## [1.1.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.0...pckg-a-v1.1.1) (2025-07-10)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-11)


### Bug Fixes

* Fix in A ([18982e5](https://github.com/d3xter666/release-please-monorepo-poc/commit/18982e5eefaaa2e8341c2a2030087939e6de3b27))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).