### PR TITLE
release: pckg-a v1.2.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/pckg-a": "1.1.2",
+  "packages/pckg-a": "1.2.0",
   "packages/pckg-b": "1.2.2",
   "packages/pckg-c": "1.1.2",
   "packages/pckg-d": "1.1.0"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-11)
+
+
+### Features
+
+* Feature in A ([3a5e067](https://github.com/d3xter666/release-please-monorepo-poc/commit/3a5e0674e171533c0dc566a62a081744cb7caa49))
+
 ## [1.1.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.1...pckg-a-v1.1.2) (2025-07-11)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-11)


### Features

* Feature in A ([3a5e067](https://github.com/d3xter666/release-please-monorepo-poc/commit/3a5e0674e171533c0dc566a62a081744cb7caa49))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).