### PR TITLE
release: pckg-a v1.2.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/pckg-a": "1.2.0",
+  "packages/pckg-a": "1.2.1",
   "packages/pckg-b": "1.2.2",
   "packages/pckg-c": "1.1.2",
   "packages/pckg-d": "1.1.0"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.0...pckg-a-v1.2.1) (2025-07-11)
+
+
+### Bug Fixes
+
+* A fix in package A ([deee24b](https://github.com/d3xter666/release-please-monorepo-poc/commit/deee24b930037ec3f6bfacd62c7f5271a8490806))
+
 ## [1.2.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.1.2...pckg-a-v1.2.0) (2025-07-11)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.0...pckg-a-v1.2.1) (2025-07-11)


### Bug Fixes

* A fix in package A ([deee24b](https://github.com/d3xter666/release-please-monorepo-poc/commit/deee24b930037ec3f6bfacd62c7f5271a8490806))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).