### PR TITLE
release: pckg-b v1.2.3

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/pckg-a": "1.3.0",
-  "packages/pckg-b": "1.2.2",
+  "packages/pckg-b": "1.2.3",
   "packages/pckg-c": "1.1.2",
   "packages/pckg-d": "1.1.0"
 }

--- a/packages/pckg-b/CHANGELOG.md
+++ b/packages/pckg-b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.3](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.2...pckg-b-v1.2.3) (2025-07-11)
+
+
+### Dependencies
+
+* **pckg-b:** Bump version due to pckg-a update ([8275602](https://github.com/d3xter666/release-please-monorepo-poc/commit/82756022b08cd85b7002c2c8fb9193ac42a80687))
+
 ## [1.2.2](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.1...pckg-b-v1.2.2) (2025-07-11)
 
 


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.2.3](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-b-v1.2.2...pckg-b-v1.2.3) (2025-07-11)


### Dependencies

* **pckg-b:** Bump version due to pckg-a update ([8275602](https://github.com/d3xter666/release-please-monorepo-poc/commit/82756022b08cd85b7002c2c8fb9193ac42a80687))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).