### PR TITLE
release: pckg-a v1.3.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/pckg-a": "1.3.0",
+  "packages/pckg-a": "1.3.1",
   "packages/pckg-b": "1.2.2",
   "packages/pckg-c": "1.1.2",
   "packages/pckg-d": "1.1.0"

--- a/packages/pckg-a/CHANGELOG.md
+++ b/packages/pckg-a/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.3.0...pckg-a-v1.3.1) (2025-07-11)
+
+
+### Bug Fixes
+
+* Pckg-A ([c583db2](https://github.com/d3xter666/release-please-monorepo-poc/commit/c583db2cc1bd6d52b45294472a80da4a2c8dc496))
+
 ## [1.3.0](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.2.1...pckg-a-v1.3.0) (2025-07-11)
 
 

--- a/packages/pckg-a/package.json
+++ b/packages/pckg-a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pckg-a",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "license": "ISC",
   "author": "",


### PR DESCRIPTION
:tractor: New release prepared
---


## [1.3.1](https://github.com/d3xter666/release-please-monorepo-poc/compare/pckg-a-v1.3.0...pckg-a-v1.3.1) (2025-07-11)


### Bug Fixes

* Pckg-A ([c583db2](https://github.com/d3xter666/release-please-monorepo-poc/commit/c583db2cc1bd6d52b45294472a80da4a2c8dc496))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).